### PR TITLE
fix(ci): pin actions to same SHAs used repo-wide

### DIFF
--- a/.github/workflows/test-npm-monorepo.yaml
+++ b/.github/workflows/test-npm-monorepo.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # https://github.com/marketplace/actions/changed-files
       - name: get changed files per package
@@ -64,11 +64,11 @@ jobs:
     steps:
       # https://github.com/marketplace/actions/checkout
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # https://github.com/marketplace/actions/cache
       - name: cache node modules
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         env:
           cache-name: cache-node-modules
         with:
@@ -77,7 +77,7 @@ jobs:
 
       # https://github.com/marketplace/actions/setup-node-js-environment
       - name: setup node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
Replaces the floating `@v6`/`@v4` action refs in `test-npm-monorepo.yaml` with the same pinned SHAs already used consistently across the rest of this repo's workflows (and matching the reusable `test-npm.yaml`):

- `actions/checkout@v6` -> `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
- `actions/cache@v4` -> `actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0`
- `actions/setup-node@v6` -> `actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0`

`tj-actions/changed-files` was already pinned correctly and is unchanged.

Verified with actionlint and task lint (pre-commit).