### PR TITLE
ci(workflows): replace deprecated app-id with client-id

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,7 +17,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,7 +17,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -59,7 +59,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           permission-pull-requests: write
 

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -59,7 +59,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           permission-pull-requests: write
 

--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -46,7 +46,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -46,7 +46,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/multi-env-dispatch.yaml
+++ b/.github/workflows/multi-env-dispatch.yaml
@@ -90,7 +90,7 @@ jobs:
       repository: jazzlyn/gh-actions-demo
       dispatch-event: ${{ needs.environment.outputs.target }}-nginx
     secrets:
-      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
   staging-dispatch:
@@ -104,7 +104,7 @@ jobs:
       repository: jazzlyn/gh-actions-demo
       dispatch-event: ${{ needs.environment.outputs.target }}-nginx
     secrets:
-      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
   # production-dispatch:
@@ -118,5 +118,5 @@ jobs:
   #     repository: jazzlyn/gh-actions-demo
   #     dispatch-event: ${{ needs.environment.outputs.target }}-nginx
   #   secrets:
-  #     github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+  #     github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
   #     github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}

--- a/.github/workflows/multi-tag-update.yaml
+++ b/.github/workflows/multi-tag-update.yaml
@@ -69,7 +69,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       - name: branch exists

--- a/.github/workflows/multi-tag-update.yaml
+++ b/.github/workflows/multi-tag-update.yaml
@@ -69,7 +69,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       - name: branch exists

--- a/.github/workflows/npm-version-bump.yaml
+++ b/.github/workflows/npm-version-bump.yaml
@@ -71,7 +71,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.github-app-id }}
+          client-id: ${{ secrets.github-app-id }}
           private-key: ${{ secrets.github-app-key }}
 
       - name: ensure branch does not exist

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -51,7 +51,7 @@ concurrency:
 #       dry-run: ${{ inputs.dry-run || 'null' }}
 #       log-level: ${{ inputs.log-level || 'debug' }}
 #     secrets:
-#       github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+#       github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
 #       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 jobs:
   renovate:
@@ -65,7 +65,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -65,7 +65,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
       # https://github.com/marketplace/actions/checkout

--- a/.github/workflows/repo-dispatch.yaml
+++ b/.github/workflows/repo-dispatch.yaml
@@ -52,7 +52,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/repo-dispatch.yaml
+++ b/.github/workflows/repo-dispatch.yaml
@@ -40,7 +40,7 @@ on:
 #       repository-owner: jazzlyn
 #       dispatch-event: test-dispatch
 #     secrets:
-#       github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+#       github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
 #       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/satis.yaml
+++ b/.github/workflows/satis.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/satis.yaml
+++ b/.github/workflows/satis.yaml
@@ -22,7 +22,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+          client-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
           private-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/tag-update.yaml
+++ b/.github/workflows/tag-update.yaml
@@ -17,7 +17,7 @@ jobs:
       commit-branch: main
       commit-message: "release(backend): update integration to ${{ github.event.client_payload.tag }}"
     secrets:
-      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
   integration-tag-update-frontend:
@@ -32,7 +32,7 @@ jobs:
       commit-branch: main
       commit-message: "release(frontend): update integration to ${{ github.event.client_payload.tag }}"
     secrets:
-      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}
 
   integration-tag-update-api:
@@ -47,5 +47,5 @@ jobs:
       commit-branch: main
       commit-message: "release(api): update integration to ${{ github.event.client_payload.tag }}"
     secrets:
-      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_APP_ID }}
+      github-app-id: ${{ secrets.JAZZLYN_BOT_GITHUB_CLIENT_ID }}
       github-app-key: ${{ secrets.JAZZLYN_BOT_GITHUB_PEM }}


### PR DESCRIPTION
github-app-id still expects "app-id", but the workflows are commented out so adapting it is fine. what a mess, thanks github.